### PR TITLE
Feature/archived messaging label

### DIFF
--- a/app/policies/channel_policy.rb
+++ b/app/policies/channel_policy.rb
@@ -4,7 +4,7 @@ class ChannelPolicy < ApplicationPolicy
 
     def resolve
       if @user.type == "Practitioner"
-        scope.where(is_private: true, user: @user.patients)
+        scope.where(is_private: true, user: @user.patients.where.not(status: "Pending"))
         .or(Channel.where(is_private: true, category: "SiteGroup", organization_id: @user.organization_id ))
         .or(Channel.where(is_private: false)).order(:organization_id, :created_at)
       elsif @user.type == "Patient"

--- a/app/serializers/channel_serializer.rb
+++ b/app/serializers/channel_serializer.rb
@@ -10,14 +10,14 @@ class ChannelSerializer < ActiveModel::Serializer
     :last_message_time,
     :user_type,
     :is_site_channel,
-    :first_message_id
+    :first_message_id,
+    :creator_is_archived
 
     def unread_messages
         return(object.messages_count - MessagingNotification.where(user_id: @instance_options[:user_id],channel_id: object.id ).first.read_message_count)
     end
 
     def title
-        
         if(@instance_options[:requesting_user_type] == "Expert" &&  object.title == "tb-expert-chat")
             return object.user.full_name
         end
@@ -30,6 +30,10 @@ class ChannelSerializer < ActiveModel::Serializer
 
     def is_private
         return object.is_private  && !object.is_site_channel
+    end
+
+    def creator_is_archived
+        object.user.patient? && object.user.status == "Archived"
     end
 
 end

--- a/app/serializers/channel_serializer.rb
+++ b/app/serializers/channel_serializer.rb
@@ -33,7 +33,7 @@ class ChannelSerializer < ActiveModel::Serializer
     end
 
     def creator_is_archived
-        object.user.patient? && object.user.status == "Archived"
+        !object.user.nil? && object.user.patient? && object.user.status == "Archived"
     end
 
 end


### PR DESCRIPTION
API side changes to add:
- Archived label to channels on the assistant side
- Stop showing channels for patients that have not yet been activated