### PR TITLE
new endpoint added to reminder flow that filters for future appointme…

### DIFF
--- a/app/controllers/v2/reminders_controller.rb
+++ b/app/controllers/v2/reminders_controller.rb
@@ -6,6 +6,11 @@ class V2::RemindersController < UserController
     render(json: reminders, status: :ok)
   end
 
+  def future_appointments
+    reminders = policy_scope(Reminder).where(patient_id: params[:patient_id]).upcoming
+    render(json: reminders, status: :ok)
+  end
+
   def create
     patient = Patient.find(params[:patient_id])
     reminder = patient.reminders.create(filter_reminder_params.merge(:creator_id => @current_user.id))

--- a/app/policies/reminder_policy.rb
+++ b/app/policies/reminder_policy.rb
@@ -25,4 +25,9 @@ class ReminderPolicy < ApplicationPolicy
   def destroy?
     @reminder.creator_id == @user.id
   end
+
+  def future_appointments?
+    @user.patient? && @reminder.patient.id == user.id
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
       resources :activation, only: [:create]
       resources :contact_tracing_surveys, only: [:index, :create]
       resources :treatment_outcome, only: [:create]
-      resources :reminders, only: [:index, :create]
+      resources :reminders, only: [:index, :create, :future_appointments]
       resource :test_medication_reminder, only: [:create], controller: "test_medication_reminder"
     end
 


### PR DESCRIPTION
On patient homepage, all appointments (past and future) are requested and sent over the network. Yet the appointment preview component on the homepage renders 'no upcoming appointments' if there are no appointments in the future. This PR aims to make a check on the backend to see if there are upcoming appointments. If there are not any, we will send back this information, instead of all reports.