### PR TITLE
added two methods to patient.rb to extract most recent photo report a…

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -327,6 +327,18 @@ class Patient < User
     self.daily_reports.last(10)
   end
 
+  
+  def most_recent_report
+    self.daily_reports.last.created_at
+  end
+
+  def most_recent_photo_report
+    self.photo_reports.last.created_at
+
+  end
+
+  
+
   def photo_days_since_last_resolution
     if (!last_general_resolution.nil?)
       return self.photo_days.where("date >= ? and date <= ?", last_general_resolution.to_date, Time.current.to_date).map { |pd| pd.date }

--- a/app/serializers/patient_issue_serializer.rb
+++ b/app/serializers/patient_issue_serializer.rb
@@ -12,7 +12,9 @@ class PatientIssueSerializer < ActiveModel::Serializer
              :treatment_start,
              :photo_days_since_last_resolution,
              :photo_schedule,
-             :next_reminder
+             :next_reminder,
+             :most_recent_report,
+             :most_recent_photo_report
 
   has_many :unreviewed_photos do
     object.photo_reports.needs_approval


### PR DESCRIPTION
…nd daily reports. We are now sending this information through with the patient_issue_serializer so that the front-end can properly address missedReport and missedPhoto logic. Currently missedReport logic is being derived from last resolution made which is causing confusion. 

Solved this ^^ issue on the client and need to sync this branch with develop so that I can test out the functionality in staging